### PR TITLE
Restrict Specialty creation to the admin role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,8 @@ class ApplicationController < ActionController::API
       render json: { errors: e.message }, status: :unauthorized
     end
   end
+
+  def permit_request
+    render json: { errors: 'This action is not permited' }, status: :forbidden if not @current_user.admin?
+  end
 end

--- a/app/controllers/specialties_controller.rb
+++ b/app/controllers/specialties_controller.rb
@@ -1,5 +1,5 @@
 class SpecialtiesController < ApplicationController
-  before_action :authorize_request
+  before_action :authorize_request, only: %i[create, update, destroy]
   before_action :set_specialty, only: %i[ show update destroy ]
   before_action :permit_request, only: %i[ create ]
 

--- a/app/controllers/specialties_controller.rb
+++ b/app/controllers/specialties_controller.rb
@@ -1,5 +1,7 @@
 class SpecialtiesController < ApplicationController
+  before_action :authorize_request
   before_action :set_specialty, only: %i[ show update destroy ]
+  before_action :permit_request, only: %i[ create ]
 
   # GET /specialties
   def index
@@ -46,6 +48,6 @@ class SpecialtiesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def specialty_params
-      params.require(:specialty).permit(:name)
+      params.permit(:name)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
   after_initialize :default_values
-  
+
 	validates :email, presence: true, uniqueness: true
 	validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 	# validates :password,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,29 +2,29 @@ class User < ApplicationRecord
   has_secure_password
   after_initialize :default_values
 
-	validates :email, presence: true, uniqueness: true
-	validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
-	# validates :password,
+  validates :email, presence: true, uniqueness: true
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  # validates :password,
   #           # length: { minimum: 8 },
   #           # if: -> { new_record? || !password.nil? }
   
-	has_one :patient
-	has_one :medic
-	has_one :record, through: :patient
-	has_one :specialty, through: :medic
+  has_one :patient
+  has_one :medic
+  has_one :record, through: :patient
+  has_one :specialty, through: :medic
 
-	enum user_type: {
-		Medico: 1,
-		Paciente: 2,
-	}
+  enum user_type: {
+    Medico: 1,
+    Paciente: 2,
+  }
 
-	def admin?
-		self.is_admin
-	end
+  def admin?
+    self.is_admin
+  end
 
-	private
+  private
 
-	def default_values
-		self.is_admin |= false
-	end
+  def default_values
+    self.is_admin |= false
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,6 @@ class User < ApplicationRecord
 	private
 
 	def default_values
-		self.is_admin = false
+		self.is_admin |= false
 	end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,10 @@ class User < ApplicationRecord
 		Paciente: 2,
 	}
 
+	def admin?
+		self.is_admin
+	end
+
 	private
 
 	def default_values

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,12 +23,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_191226) do
     t.index ["patient_id"], name: "index_appointments_on_patient_id"
   end
 
-  create_table "especialidades", force: :cascade do |t|
-    t.string "nome"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "medics", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "specialty_id", null: false


### PR DESCRIPTION
## Sem autorização (não é admin)
Se tentarmos criar uma especialidade usando o seguinte token de login:

![token](https://github.com/the-bugs/medcheck-backend-rails/assets/5000206/cb84211b-255d-44b1-9efb-36a45952bc2f)

Podemos ver que esse usuário não é administrador

![not_admin_user](https://github.com/the-bugs/medcheck-backend-rails/assets/5000206/73582f1d-8949-495f-8fb0-94fba23814de)

Sendo assim, ao acessar a rota de criação de specialidade com esse usuário que não é admin, recebemos de volta uma resposta com 403 (Forbidden)
![forbidden](https://github.com/the-bugs/medcheck-backend-rails/assets/5000206/05e2d1ac-b865-49c7-b230-eded28e6516d)

## Com autorização (é admin)
Agora, se usarmos o seguinte token

![admin_token](https://github.com/the-bugs/medcheck-backend-rails/assets/5000206/e8df2a60-4a84-4de2-a9c7-58c97a55fda5)

para acessar o sistema que o seguinte usuário (que é administrador)

![admin_user](https://github.com/the-bugs/medcheck-backend-rails/assets/5000206/426db81d-946a-41c7-ba10-210c973e5804)


Conseguiremos criar uma especialidade

![speacialty_created](https://github.com/the-bugs/medcheck-backend-rails/assets/5000206/fac6f11c-845b-4218-87a4-d859228a82b6)


